### PR TITLE
[케이] Chapter 6. API 설계 기초 - JPA

### DIFF
--- a/src/main/java/com/example/umc10th/Umc10thApplication.java
+++ b/src/main/java/com/example/umc10th/Umc10thApplication.java
@@ -2,7 +2,9 @@ package com.example.umc10th;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Umc10thApplication {
 

--- a/src/main/java/com/example/umc10th/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/umc10th/domain/member/controller/MemberController.java
@@ -35,8 +35,12 @@ public class MemberController {
 
     // 2. 홈 화면 조회
     @GetMapping("/home")
-    public ApiResponse<MemberResDTO.Home> getHome(@RequestParam Long memberId) { // @RequestParam: URL 뒤에 붙는 쿼리 파라미터를 받을 때 쓴다.
-        MemberResDTO.Home result = memberService.getHome(memberId);
+    public ApiResponse<MemberResDTO.Home> getHome(
+            @RequestParam Long memberId,
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size
+    ) { // @RequestParam: URL 뒤에 붙는 쿼리 파라미터를 받을 때 쓴다.
+        MemberResDTO.Home result = memberService.getHome(memberId, page, size);
         return ApiResponse.onSuccess(MemberSuccessCode.GET_HOME, result);
     }
 

--- a/src/main/java/com/example/umc10th/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/umc10th/domain/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.example.umc10th.domain.member.controller;
 import com.example.umc10th.domain.member.dto.MemberReqDTO;
 import com.example.umc10th.domain.member.dto.MemberResDTO;
 import com.example.umc10th.domain.member.exception.code.MemberSuccessCode;
+import com.example.umc10th.domain.member.service.MemberService;
 import com.example.umc10th.global.apiPayload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -15,7 +16,7 @@ import java.util.List;
 @RequestMapping("/api/v1")
 public class MemberController {
 
-    // private final MemberService memberService;  // 6주차에 활성화하기!
+    private final MemberService memberService;
 
     // 1. 회원가입
     @PostMapping("/auth/signup")
@@ -34,55 +35,15 @@ public class MemberController {
 
     // 2. 홈 화면 조회
     @GetMapping("/home")
-    public ApiResponse<MemberResDTO.Home> getHome() {
-        // 6주차에서 memberService.getHome()로 교체
-        MemberResDTO.HomeMember member = MemberResDTO.HomeMember.builder()
-                .memberId(1L)
-                .nickname("kei")
-                .point(2500)
-                .build();
-
-        MemberResDTO.MissionSummary summary = MemberResDTO.MissionSummary.builder()
-                .receivedCount(7)
-                .completedCount(2)
-                .inProgressCount(5)
-                .build();
-
-        List<MemberResDTO.ReceivedMission> missions = List.of(
-                MemberResDTO.ReceivedMission.builder()
-                        .memberMissionId(101L)
-                        .missionId(10L)
-                        .storeId(3L)
-                        .storeName("KFC")
-                        .condition("10,000원 이상 주문 시")
-                        .rewardPoint(500)
-                        .status("IN_PROGRESS")
-                        .deadline(LocalDate.of(2026, 3, 31))
-                        .build()
-        );
-
-        MemberResDTO.Home result = MemberResDTO.Home.builder()
-                .member(member)
-                .missionSummary(summary)
-                .receivedMissions(missions)
-                .build();
-
+    public ApiResponse<MemberResDTO.Home> getHome(@RequestParam Long memberId) { // @RequestParam: URL 뒤에 붙는 쿼리 파라미터를 받을 때 쓴다.
+        MemberResDTO.Home result = memberService.getHome(memberId);
         return ApiResponse.onSuccess(MemberSuccessCode.GET_HOME, result);
     }
 
     // 3. 마이페이지 조회
     @GetMapping("/members/me")
-    public ApiResponse<MemberResDTO.MyPage> getMyPage() {
-        // 6주차에서 memberService.getMyPage()로 교체
-        MemberResDTO.MyPage result = MemberResDTO.MyPage.builder()
-                .memberId(1L)
-                .nickname("kei")
-                .email("harim@naver.com")
-                .phoneNumber("01012345678")
-                .point(2500)
-                .profileUrl("https://cdn.example.com/profile/default.png")
-                .build();
-
+    public ApiResponse<MemberResDTO.MyPage> getMyPage(@RequestParam Long memberId) {
+        MemberResDTO.MyPage result = memberService.getMyPage(memberId);
         return ApiResponse.onSuccess(MemberSuccessCode.GET_MY_PAGE, result);
     }
 }

--- a/src/main/java/com/example/umc10th/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/umc10th/domain/member/converter/MemberConverter.java
@@ -1,4 +1,67 @@
 package com.example.umc10th.domain.member.converter;
 
+import com.example.umc10th.domain.member.dto.MemberResDTO;
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+
+import java.util.List;
+
 public class MemberConverter {
+
+    // 마이페이지 변환
+    public static MemberResDTO.MyPage toMyPage(Member member) {
+        return MemberResDTO.MyPage.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .phoneNumber(member.getPhoneNumber())
+                .point(member.getPoint())
+                .profileUrl(member.getProfileUrl())
+                .build();
+    }
+
+    // 홈 - 회원 정보
+    public static MemberResDTO.HomeMember toHomeMember(Member member) {
+        return MemberResDTO.HomeMember.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .point(member.getPoint())
+                .build();
+    }
+
+    // 홈 - 미션 요약
+    public static MemberResDTO.MissionSummary toMissionSummary(Long received, Long completed, Long inProgress) {
+        return MemberResDTO.MissionSummary.builder()
+                .receivedCount(received.intValue())
+                .completedCount(completed.intValue())
+                .inProgressCount(inProgress.intValue())
+                .build();
+    }
+
+    // 홈 - 받은 미션 단건
+    public static MemberResDTO.ReceivedMission toReceivedMission(MemberMission mm) {
+        return MemberResDTO.ReceivedMission.builder()
+                .memberMissionId(mm.getId())
+                .missionId(mm.getMission().getId())
+                .storeId(mm.getMission().getStore().getId())
+                .storeName(mm.getMission().getStore().getName())
+                .condition(mm.getMission().getConditional())
+                .rewardPoint(mm.getMission().getPoint())
+                .status(mm.isComplete() ? "COMPLETED" : "IN_PROGRESS")
+                .deadline(mm.getMission().getDeadline())
+                .build();
+    }
+
+    // 홈 - 전체 응답
+    public static MemberResDTO.Home toHome(Member member, Long received, Long completed, Long inProgress, List<MemberMission> receivedMissions) {
+        List<MemberResDTO.ReceivedMission> missionList = receivedMissions.stream()// receivedMissions.stream(): receivedMissions 라는 리스트를 하나씩 처리하기 위해 스트림으로 변환
+                .map(MemberConverter::toReceivedMission) // 리스트 안에 있는 각 엔티티를 DTO로 변환
+                .toList(); // 변환된 것들을 리스트로 묶어서 반환
+
+        return MemberResDTO.Home.builder()
+                .member(toHomeMember(member)) // 회원 정보 변환
+                .missionSummary(toMissionSummary(received, completed, inProgress)) // 미션 요약 변환
+                .receivedMissions(missionList) // 받은 미션 리스트 설정
+                .build();
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/umc10th/domain/member/converter/MemberConverter.java
@@ -3,6 +3,7 @@ package com.example.umc10th.domain.member.converter;
 import com.example.umc10th.domain.member.dto.MemberResDTO;
 import com.example.umc10th.domain.member.entity.Member;
 import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -53,15 +54,28 @@ public class MemberConverter {
     }
 
     // 홈 - 전체 응답
-    public static MemberResDTO.Home toHome(Member member, Long received, Long completed, Long inProgress, List<MemberMission> receivedMissions) {
-        List<MemberResDTO.ReceivedMission> missionList = receivedMissions.stream()// receivedMissions.stream(): receivedMissions 라는 리스트를 하나씩 처리하기 위해 스트림으로 변환
-                .map(MemberConverter::toReceivedMission) // 리스트 안에 있는 각 엔티티를 DTO로 변환
-                .toList(); // 변환된 것들을 리스트로 묶어서 반환
+    public static MemberResDTO.Home toHome(
+            Member member, Long received, Long completed, Long inProgress,
+            Page<MemberMission> missionPage
+    ) {
+        // 1. Page에서 실제 데이터(List)를 꺼내서 DTO로 변환
+        List<MemberResDTO.ReceivedMission> missionList = missionPage.getContent().stream() // Page에서 실제 데이터 리스트를 가져옴
+                .map(MemberConverter::toReceivedMission)
+                .toList();
+
+        // 2. Page에서 페이징 정보 꺼내서 PageInfo DTO 생성
+        MemberResDTO.PageInfo pageInfo = MemberResDTO.PageInfo.builder()
+                .page(missionPage.getNumber())
+                .size(missionPage.getSize())
+                .totalElements(missionPage.getTotalElements())
+                .totalPages(missionPage.getTotalPages())
+                .build();
 
         return MemberResDTO.Home.builder()
                 .member(toHomeMember(member)) // 회원 정보 변환
                 .missionSummary(toMissionSummary(received, completed, inProgress)) // 미션 요약 변환
                 .receivedMissions(missionList) // 받은 미션 리스트 설정
+                .pageInfo(pageInfo)
                 .build();
     }
 }

--- a/src/main/java/com/example/umc10th/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/umc10th/domain/member/converter/MemberConverter.java
@@ -64,19 +64,11 @@ public class MemberConverter {
                 .map(MemberConverter::toReceivedMission)
                 .toList();
 
-        // 2. Page에서 페이징 정보 꺼내서 PageInfo DTO 생성
-        PageInfoDTO pageInfo = PageInfoDTO.builder()
-                .page(missionPage.getNumber())
-                .size(missionPage.getSize())
-                .totalElements(missionPage.getTotalElements())
-                .totalPages(missionPage.getTotalPages())
-                .build();
-
         return MemberResDTO.Home.builder()
                 .member(toHomeMember(member)) // 회원 정보 변환
                 .missionSummary(toMissionSummary(received, completed, inProgress)) // 미션 요약 변환
                 .receivedMissions(missionList) // 받은 미션 리스트 설정
-                .pageInfo(pageInfo)
+                .pageInfo(PageInfoDTO.from(missionPage)) // 페이지 정보 변환
                 .build();
     }
 }

--- a/src/main/java/com/example/umc10th/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/umc10th/domain/member/converter/MemberConverter.java
@@ -3,6 +3,7 @@ package com.example.umc10th.domain.member.converter;
 import com.example.umc10th.domain.member.dto.MemberResDTO;
 import com.example.umc10th.domain.member.entity.Member;
 import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+import com.example.umc10th.global.dto.PageInfoDTO;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -64,7 +65,7 @@ public class MemberConverter {
                 .toList();
 
         // 2. Page에서 페이징 정보 꺼내서 PageInfo DTO 생성
-        MemberResDTO.PageInfo pageInfo = MemberResDTO.PageInfo.builder()
+        PageInfoDTO pageInfo = PageInfoDTO.builder()
                 .page(missionPage.getNumber())
                 .size(missionPage.getSize())
                 .totalElements(missionPage.getTotalElements())

--- a/src/main/java/com/example/umc10th/domain/member/dto/MemberResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/member/dto/MemberResDTO.java
@@ -44,12 +44,22 @@ public class MemberResDTO {
             LocalDate deadline
     ) {}
 
+    // 페이지 정보
+    @Builder
+    public record PageInfo(
+            Integer page,
+            Integer size,
+            Long totalElements,
+            Integer totalPages
+    ) {}
+
     // 홈 화면 응답 (최종)
     @Builder
     public record Home(
             HomeMember member,
             MissionSummary missionSummary,
-            List<ReceivedMission> receivedMissions
+            List<ReceivedMission> receivedMissions,
+            PageInfo pageInfo
     ) {}
 
     // 마이페이지 응답

--- a/src/main/java/com/example/umc10th/domain/member/dto/MemberResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/member/dto/MemberResDTO.java
@@ -1,5 +1,6 @@
 package com.example.umc10th.domain.member.dto;
 
+import com.example.umc10th.global.dto.PageInfoDTO;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -44,22 +45,13 @@ public class MemberResDTO {
             LocalDate deadline
     ) {}
 
-    // 페이지 정보
-    @Builder
-    public record PageInfo(
-            Integer page,
-            Integer size,
-            Long totalElements,
-            Integer totalPages
-    ) {}
-
     // 홈 화면 응답 (최종)
     @Builder
     public record Home(
             HomeMember member,
             MissionSummary missionSummary,
             List<ReceivedMission> receivedMissions,
-            PageInfo pageInfo
+            PageInfoDTO pageInfo
     ) {}
 
     // 마이페이지 응답

--- a/src/main/java/com/example/umc10th/domain/member/entity/Food.java
+++ b/src/main/java/com/example/umc10th/domain/member/entity/Food.java
@@ -1,4 +1,30 @@
 package com.example.umc10th.domain.member.entity;
 
+import com.example.umc10th.domain.member.entity.mapping.MemberFood;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "food")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Food {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private com.example.umc10th.domain.member.enums.Food name;
+    // 엔티티명(Food)과 enum명(Food)이 같아서 풀 경로로 작성
+
+    @OneToMany(mappedBy = "food", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<MemberFood> memberFoodList = new ArrayList<>();
 }

--- a/src/main/java/com/example/umc10th/domain/member/entity/Member.java
+++ b/src/main/java/com/example/umc10th/domain/member/entity/Member.java
@@ -41,6 +41,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 10)
     private String nickname;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Address address;
 

--- a/src/main/java/com/example/umc10th/domain/member/entity/Member.java
+++ b/src/main/java/com/example/umc10th/domain/member/entity/Member.java
@@ -1,4 +1,87 @@
 package com.example.umc10th.domain.member.entity;
 
-public class Member {
+import com.example.umc10th.domain.member.entity.mapping.MemberFood;
+import com.example.umc10th.domain.member.entity.mapping.MemberTerm;
+import com.example.umc10th.domain.member.enums.Gender;
+import com.example.umc10th.domain.member.enums.SocialType;
+import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+import com.example.umc10th.domain.review.entity.Review;
+import com.example.umc10th.global.entity.BaseEntity;
+import com.example.umc10th.global.enums.Address;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "member")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Member extends BaseEntity {
+
+    @Id // PK 임을 알림
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // PK 값을 개발자가 직접 넣는 게 아닌 DB가 자동으로 생성하도록 설정
+    private Long id;
+
+    @Column(nullable = false, length = 5)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private Gender gender = Gender.NONE;
+
+    @Column(nullable = false)
+    private LocalDate birth;
+
+    @Column(nullable = false, length = 10)
+    private String nickname;
+
+    @Column(nullable = false)
+    private Address address;
+
+    @Column(name = "detail_address", nullable = false, length = 255)
+    private String detailAddress;
+
+    @Column(name = "social_uid", nullable = false, length = 255)
+    private String socialUid;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_type", nullable = false)
+    private SocialType socialType;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer point = 0;
+
+    @Column(nullable = false, length = 50)
+    private String email;
+
+    @Column(name = "phone_number", length = 11)
+    private String phoneNumber;
+
+    // columnDefinition = "TEXT": 255자 이상의 대용량 텍스트 저장 가능 타입으로 지정
+    @Column(name = "profile_url", columnDefinition = "TEXT", nullable = false)
+    private String profileUrl;
+
+    // 연관 관계
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<MemberFood> memberFoodList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<MemberTerm> memberTermList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<MemberMission> memberMissionList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<Review> reviewList = new ArrayList<>();
 }

--- a/src/main/java/com/example/umc10th/domain/member/entity/Term.java
+++ b/src/main/java/com/example/umc10th/domain/member/entity/Term.java
@@ -1,4 +1,30 @@
 package com.example.umc10th.domain.member.entity;
 
+import com.example.umc10th.domain.member.entity.mapping.MemberTerm;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "term")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Term {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private com.example.umc10th.domain.member.enums.Term name;
+    // ↑ 엔티티명(Term)과 enum명(Term)이 같아서 풀 경로로 작성
+
+    @OneToMany(mappedBy = "term", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<MemberTerm> memberTermList = new ArrayList<>();
 }

--- a/src/main/java/com/example/umc10th/domain/member/entity/mapping/MemberFood.java
+++ b/src/main/java/com/example/umc10th/domain/member/entity/mapping/MemberFood.java
@@ -1,4 +1,28 @@
 package com.example.umc10th.domain.member.entity.mapping;
 
-public class MemberFood {
+import com.example.umc10th.domain.member.entity.Food;
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "member_food")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberFood extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_id", nullable = false)
+    private Food food;
 }

--- a/src/main/java/com/example/umc10th/domain/member/entity/mapping/MemberTerm.java
+++ b/src/main/java/com/example/umc10th/domain/member/entity/mapping/MemberTerm.java
@@ -1,4 +1,28 @@
 package com.example.umc10th.domain.member.entity.mapping;
 
-public class MemberTerm {
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.member.entity.Term;
+import com.example.umc10th.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "member_term")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberTerm extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id", nullable = false)
+    private Term term;
 }

--- a/src/main/java/com/example/umc10th/domain/member/enums/Food.java
+++ b/src/main/java/com/example/umc10th/domain/member/enums/Food.java
@@ -1,0 +1,6 @@
+package com.example.umc10th.domain.member.enums;
+
+public enum Food {
+    NONE, KOREAN, JAPANESE, CHINESE, WESTERN, FAST_FOOD,
+    DESSERT, ASIAN_FOOD, MEAT, LATE_NIGHT
+}

--- a/src/main/java/com/example/umc10th/domain/member/enums/Gender.java
+++ b/src/main/java/com/example/umc10th/domain/member/enums/Gender.java
@@ -1,4 +1,5 @@
 package com.example.umc10th.domain.member.enums;
 
 public enum Gender {
+    NONE, MALE, FEMALE
 }

--- a/src/main/java/com/example/umc10th/domain/member/enums/SocialType.java
+++ b/src/main/java/com/example/umc10th/domain/member/enums/SocialType.java
@@ -1,4 +1,5 @@
 package com.example.umc10th.domain.member.enums;
 
 public enum SocialType {
+    KAKAO, NAVER, APPLE, GOOGLE
 }

--- a/src/main/java/com/example/umc10th/domain/member/enums/Term.java
+++ b/src/main/java/com/example/umc10th/domain/member/enums/Term.java
@@ -1,4 +1,5 @@
 package com.example.umc10th.domain.member.enums;
 
 public enum Term {
+    AGE, SERVICE, PRIVACY, LOCATION, MARKETING
 }

--- a/src/main/java/com/example/umc10th/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/umc10th/domain/member/repository/MemberRepository.java
@@ -1,4 +1,9 @@
 package com.example.umc10th.domain.member.repository;
 
-public interface MemberRepository {
+import com.example.umc10th.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// JpaRepository: Spring Data JPA가 제공하는 인터페이스로, 기본적인 CRUD 메서드를 자동으로 구현해준다.
+// <Member, Long>: 이 Repository는 Member 엔터티를 관리하며, Member 엔터티의 기본 키(PK) 타입이 Long임을 나타낸다.
+public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/src/main/java/com/example/umc10th/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/umc10th/domain/member/service/MemberService.java
@@ -9,6 +9,9 @@ import com.example.umc10th.domain.member.repository.MemberRepository;
 import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
 import com.example.umc10th.domain.mission.repository.MemberMissionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,18 +33,21 @@ public class MemberService {
     }
 
     // 홈 화면
-    public MemberResDTO.Home getHome(Long memberId) {
+    public MemberResDTO.Home getHome(Long memberId, Integer page, Integer size) {
+        // 1. Member 조회
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        // 미션 카운트 조회
+        // 2. 미션 카운트 조회
         Long received = memberMissionRepository.countByMemberId(memberId);
         Long completed = memberMissionRepository.countByMemberIdAndStatus(memberId, true);
         Long inProgress = memberMissionRepository.countByMemberIdAndStatus(memberId, false);
 
-        // 받은 미션 목록 조회
-        List<MemberMission> missions = memberMissionRepository.findAllByMemberId(memberId);
+        // 3. Pageable 생성 후 페이징 쿼리 호출
+        Pageable pageable = PageRequest.of(page, size);
+        Page<MemberMission> missionPage = memberMissionRepository.findAllByMemberId(memberId, pageable);
 
-        return MemberConverter.toHome(member, received, completed, inProgress, missions);
+        // 4. 컨버터로 변환
+        return MemberConverter.toHome(member, received, completed, inProgress, missionPage);
     }
 }

--- a/src/main/java/com/example/umc10th/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/umc10th/domain/member/service/MemberService.java
@@ -1,4 +1,47 @@
 package com.example.umc10th.domain.member.service;
 
+import com.example.umc10th.domain.member.converter.MemberConverter;
+import com.example.umc10th.domain.member.dto.MemberResDTO;
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.member.exception.MemberException;
+import com.example.umc10th.domain.member.exception.code.MemberErrorCode;
+import com.example.umc10th.domain.member.repository.MemberRepository;
+import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+import com.example.umc10th.domain.mission.repository.MemberMissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor // final 필드를 파라미터로 받는 생성자를 자동으로 생성해준다. (의존성 주입 편리하게)
+@Transactional(readOnly = true)
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final MemberMissionRepository memberMissionRepository;
+
+    // 마이페이지
+    public MemberResDTO.MyPage getMyPage(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        return MemberConverter.toMyPage(member);
+    }
+
+    // 홈 화면
+    public MemberResDTO.Home getHome(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 미션 카운트 조회
+        Long received = memberMissionRepository.countByMemberId(memberId);
+        Long completed = memberMissionRepository.countByMemberIdAndStatus(memberId, true);
+        Long inProgress = memberMissionRepository.countByMemberIdAndStatus(memberId, false);
+
+        // 받은 미션 목록 조회
+        List<MemberMission> missions = memberMissionRepository.findAllByMemberId(memberId);
+
+        return MemberConverter.toHome(member, received, completed, inProgress, missions);
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
@@ -3,6 +3,7 @@ package com.example.umc10th.domain.mission.controller;
 import com.example.umc10th.domain.mission.dto.MissionReqDTO;
 import com.example.umc10th.domain.mission.dto.MissionResDTO;
 import com.example.umc10th.domain.mission.exception.code.MissionSuccessCode;
+import com.example.umc10th.domain.mission.service.MissionService;
 import com.example.umc10th.global.apiPayload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,42 +17,17 @@ import java.util.List;
 @RequestMapping("/api/v1")
 public class MissionController {
 
-    // private final MissionService missionService; 6주차에 활성화하기!
+    private final MissionService missionService;
 
     // 4. 미션 목록 조회 (진행중 / 진행완료 통합)
     @GetMapping("/member-missions")
     public ApiResponse<MissionResDTO.MissionList> getMemberMissions(
+            @RequestParam Long memberId,
             @RequestParam String status,         // "IN_PROGRESS" or "COMPLETED"
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "10") Integer size
     ) {
-        // 6주차에서 missionService.getMemberMissions(status, page, size)로 교체
-        List<MissionResDTO.MissionInfo> missions = List.of(
-                MissionResDTO.MissionInfo.builder()
-                        .memberMissionId(101L)
-                        .missionId(10L)
-                        .storeId(3L)
-                        .storeName("현안국밥")
-                        .condition("10,000원 이상 주문 시")
-                        .rewardPoint(500)
-                        .status("IN_PROGRESS")
-                        .deadline(LocalDate.of(2026, 3, 31))
-                        .completedAt(null)
-                        .build()
-        );
-
-        MissionResDTO.PageInfo pageInfo = MissionResDTO.PageInfo.builder()
-                .page(page)
-                .size(size)
-                .totalElements(24L)
-                .totalPages(3)
-                .build();
-
-        MissionResDTO.MissionList result = MissionResDTO.MissionList.builder()
-                .missions(missions)
-                .pageInfo(pageInfo)
-                .build();
-
+        MissionResDTO.MissionList result = missionService.getMemberMissions(memberId, status, page, size);
         return ApiResponse.onSuccess(MissionSuccessCode.GET_MISSION_LIST, result);
     }
 

--- a/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
+++ b/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
@@ -1,6 +1,5 @@
 package com.example.umc10th.domain.mission.converter;
 
-import com.example.umc10th.domain.member.entity.Member;
 import com.example.umc10th.domain.mission.dto.MissionResDTO;
 import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
+++ b/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
@@ -11,6 +11,7 @@ public class MissionConverter {
     // 미션 단건 정보
     public static MissionResDTO.MissionInfo toMissionInfo(MemberMission mm) {
         return MissionResDTO.MissionInfo.builder()
+                .memberMissionId(mm.getId())
                 .missionId(mm.getMission().getId())
                 .storeId(mm.getMission().getStore().getId())
                 .storeName(mm.getMission().getStore().getName())

--- a/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
+++ b/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
@@ -1,4 +1,47 @@
 package com.example.umc10th.domain.mission.converter;
 
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.mission.dto.MissionResDTO;
+import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
 public class MissionConverter {
+
+    // 미션 단건 정보
+    public static MissionResDTO.MissionInfo toMissionInfo(MemberMission mm) {
+        return MissionResDTO.MissionInfo.builder()
+                .missionId(mm.getMission().getId())
+                .storeId(mm.getMission().getStore().getId())
+                .storeName(mm.getMission().getStore().getName())
+                .condition(mm.getMission().getConditional())
+                .rewardPoint(mm.getMission().getPoint())
+                .status(mm.isComplete() ? "COMPLETED" : "IN_PROGRESS")
+                .deadline(mm.getMission().getDeadline())
+                .completedAt(mm.isComplete() ? mm.getUpdatedAt() : null)
+                .build();
+    }
+
+    // 페이지 정보
+    public static MissionResDTO.PageInfo toPageInfo(Page<MemberMission> page) {
+        return MissionResDTO.PageInfo.builder()
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
+    }
+
+    // 전체 응답(미션 목록 응답) (페이징 포함!)
+    public static MissionResDTO.MissionList toMissionList(Page<MemberMission> page) {
+        List<MissionResDTO.MissionInfo> missions = page.getContent().stream()
+                .map(MissionConverter::toMissionInfo)
+                .toList();
+
+        return MissionResDTO.MissionList.builder()
+                .missions(missions)
+                .pageInfo(toPageInfo(page))
+                .build();
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
+++ b/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
@@ -24,16 +24,6 @@ public class MissionConverter {
                 .build();
     }
 
-    // 페이지 정보
-    public static PageInfoDTO toPageInfo(Page<MemberMission> page) {
-        return PageInfoDTO.builder()
-                .page(page.getNumber())
-                .size(page.getSize())
-                .totalElements(page.getTotalElements())
-                .totalPages(page.getTotalPages())
-                .build();
-    }
-
     // 전체 응답(미션 목록 응답) (페이징 포함!)
     public static MissionResDTO.MissionList toMissionList(Page<MemberMission> page) {
         List<MissionResDTO.MissionInfo> missions = page.getContent().stream()
@@ -42,7 +32,7 @@ public class MissionConverter {
 
         return MissionResDTO.MissionList.builder()
                 .missions(missions)
-                .pageInfo(toPageInfo(page))
+                .pageInfo(PageInfoDTO.from(page))
                 .build();
     }
 }

--- a/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
+++ b/src/main/java/com/example/umc10th/domain/mission/converter/MissionConverter.java
@@ -2,6 +2,7 @@ package com.example.umc10th.domain.mission.converter;
 
 import com.example.umc10th.domain.mission.dto.MissionResDTO;
 import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+import com.example.umc10th.global.dto.PageInfoDTO;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -24,8 +25,8 @@ public class MissionConverter {
     }
 
     // 페이지 정보
-    public static MissionResDTO.PageInfo toPageInfo(Page<MemberMission> page) {
-        return MissionResDTO.PageInfo.builder()
+    public static PageInfoDTO toPageInfo(Page<MemberMission> page) {
+        return PageInfoDTO.builder()
                 .page(page.getNumber())
                 .size(page.getSize())
                 .totalElements(page.getTotalElements())

--- a/src/main/java/com/example/umc10th/domain/mission/dto/MissionResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/mission/dto/MissionResDTO.java
@@ -1,5 +1,6 @@
 package com.example.umc10th.domain.mission.dto;
 
+import com.example.umc10th.global.dto.PageInfoDTO;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -22,20 +23,11 @@ public class MissionResDTO {
             LocalDateTime completedAt
     ) {}
 
-    // 페이지 정보
-    @Builder
-    public record PageInfo(
-            Integer page,
-            Integer size,
-            Long totalElements,
-            Integer totalPages
-    ) {}
-
     // 미션 목록 응답
     @Builder
     public record MissionList(
             List<MissionInfo> missions,
-            PageInfo pageInfo
+            PageInfoDTO pageInfo
     ) {}
 
     // 미션 성공 응답

--- a/src/main/java/com/example/umc10th/domain/mission/entity/Location.java
+++ b/src/main/java/com/example/umc10th/domain/mission/entity/Location.java
@@ -1,4 +1,29 @@
 package com.example.umc10th.domain.mission.entity;
 
+import com.example.umc10th.global.enums.Address;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "location")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class Location {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Address address;
+
+    @OneToMany(mappedBy = "location", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<Store> storeList = new ArrayList<>();
 }

--- a/src/main/java/com/example/umc10th/domain/mission/entity/Mission.java
+++ b/src/main/java/com/example/umc10th/domain/mission/entity/Mission.java
@@ -1,4 +1,40 @@
 package com.example.umc10th.domain.mission.entity;
 
-public class Mission {
+import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+import com.example.umc10th.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "mission")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Mission extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate deadline;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String conditional;
+
+    @Column(nullable = false)
+    private Integer point;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @OneToMany(mappedBy = "mission", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<MemberMission> memberMissionList = new ArrayList<>();
 }

--- a/src/main/java/com/example/umc10th/domain/mission/entity/Store.java
+++ b/src/main/java/com/example/umc10th/domain/mission/entity/Store.java
@@ -1,4 +1,45 @@
 package com.example.umc10th.domain.mission.entity;
 
+import com.example.umc10th.domain.review.entity.Review;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "store")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "food_type", nullable = false, length = 10)
+    private String foodType;
+
+    @Column(name = "manager_number", nullable = false)
+    private Long managerNumber;
+
+    @Column(name = "detail_address", nullable = false, length = 255)
+    private String detailAddress;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", nullable = false)
+    private Location location;
+
+    @OneToMany(mappedBy = "store", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<Mission> missionList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "store", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<Review> reviewList = new ArrayList<>();
 }

--- a/src/main/java/com/example/umc10th/domain/mission/entity/mapping/MemberMission.java
+++ b/src/main/java/com/example/umc10th/domain/mission/entity/mapping/MemberMission.java
@@ -1,4 +1,32 @@
 package com.example.umc10th.domain.mission.entity.mapping;
 
-public class MemberMission {
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.mission.entity.Mission;
+import com.example.umc10th.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "member_mission")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberMission extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "is_complete", nullable = false)
+    @Builder.Default
+    private boolean isComplete = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 }

--- a/src/main/java/com/example/umc10th/domain/mission/enums/Address.java
+++ b/src/main/java/com/example/umc10th/domain/mission/enums/Address.java
@@ -1,4 +1,0 @@
-package com.example.umc10th.domain.mission.enums;
-
-public enum Address {
-}

--- a/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MissionErrorCode implements BaseErrorCode {
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404_1", "해당 미션을 찾을 수 없습니다."),
-    MISSION_ALREADY_COMPLETED(HttpStatus.CONFLICT, "MISSION409_1", "이미 완료된 미션입니다.");
+    MISSION_ALREADY_COMPLETED(HttpStatus.CONFLICT, "MISSION409_1", "이미 완료된 미션입니다."),
+    MEMBER_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404_2", "사용자 미션을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/umc10th/domain/mission/repository/MemberMissionRepository.java
+++ b/src/main/java/com/example/umc10th/domain/mission/repository/MemberMissionRepository.java
@@ -15,7 +15,7 @@ public interface MemberMissionRepository extends JpaRepository<MemberMission, Lo
     @Query("SELECT mm FROM MemberMission mm " +
             "WHERE mm.member.id = :memberId " +
             "AND mm.isComplete = :isComplete")
-    Page<MemberMission> findMemberIdAndStatus(
+    Page<MemberMission> findByMemberIdAndStatus(
             @Param("memberId") Long memberId,
             @Param("isComplete") Boolean isComplete,
             Pageable pageable

--- a/src/main/java/com/example/umc10th/domain/mission/repository/MemberMissionRepository.java
+++ b/src/main/java/com/example/umc10th/domain/mission/repository/MemberMissionRepository.java
@@ -23,7 +23,10 @@ public interface MemberMissionRepository extends JpaRepository<MemberMission, Lo
 
     // 홈 화면용: 내가 받은 모든 미션 (status별 카운트용)
     @Query("SELECT mm FROM MemberMission mm WHERE mm.member.id = :memberId")
-    List<MemberMission> findAllByMemberId(@Param("memberId") Long memberId);
+    Page<MemberMission> findAllByMemberId(
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
 
     // 카운트 쿼리들 (홈 화면 미션 요약용)
     @Query("SELECT COUNT(mm) FROM MemberMission mm WHERE mm.member.id = :memberId")

--- a/src/main/java/com/example/umc10th/domain/mission/repository/MemberMissionRepository.java
+++ b/src/main/java/com/example/umc10th/domain/mission/repository/MemberMissionRepository.java
@@ -13,6 +13,8 @@ public interface MemberMissionRepository extends JpaRepository<MemberMission, Lo
 
     // 내 미션 (진행중 / 완료 상태별 페이징) - @Query 사용
     @Query("SELECT mm FROM MemberMission mm " +
+            "JOIN FETCH mm.mission m " +
+            "JOIN FETCH m.store " +
             "WHERE mm.member.id = :memberId " +
             "AND mm.isComplete = :isComplete")
     Page<MemberMission> findByMemberIdAndStatus(
@@ -22,7 +24,10 @@ public interface MemberMissionRepository extends JpaRepository<MemberMission, Lo
     );
 
     // 홈 화면용: 내가 받은 모든 미션 (status별 카운트용)
-    @Query("SELECT mm FROM MemberMission mm WHERE mm.member.id = :memberId")
+    @Query("SELECT mm FROM MemberMission mm " +
+            "JOIN FETCH mm.mission m " +
+            "JOIN FETCH m.store " +
+            "WHERE mm.member.id = :memberId")
     Page<MemberMission> findAllByMemberId(
             @Param("memberId") Long memberId,
             Pageable pageable

--- a/src/main/java/com/example/umc10th/domain/mission/repository/MemberMissionRepository.java
+++ b/src/main/java/com/example/umc10th/domain/mission/repository/MemberMissionRepository.java
@@ -1,0 +1,38 @@
+package com.example.umc10th.domain.mission.repository;
+
+import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MemberMissionRepository extends JpaRepository<MemberMission, Long> {
+
+    // 내 미션 (진행중 / 완료 상태별 페이징) - @Query 사용
+    @Query("SELECT mm FROM MemberMission mm " +
+            "WHERE mm.member.id = :memberId " +
+            "AND mm.isComplete = :isComplete")
+    Page<MemberMission> findMemberIdAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("isComplete") Boolean isComplete,
+            Pageable pageable
+    );
+
+    // 홈 화면용: 내가 받은 모든 미션 (status별 카운트용)
+    @Query("SELECT mm FROM MemberMission mm WHERE mm.member.id = :memberId")
+    List<MemberMission> findAllByMemberId(@Param("memberId") Long memberId);
+
+    // 카운트 쿼리들 (홈 화면 미션 요약용)
+    @Query("SELECT COUNT(mm) FROM MemberMission mm WHERE mm.member.id = :memberId")
+    Long countByMemberId(@Param("memberId") Long memberId);
+
+    @Query("SELECT COUNT(mm) FROM MemberMission mm " +
+            "WHERE mm.member.id = :memberId AND mm.isComplete = :isComplete")
+    Long countByMemberIdAndStatus(
+            @Param("memberId") Long memberId,
+            @Param("isComplete") Boolean isComplete
+    );
+}

--- a/src/main/java/com/example/umc10th/domain/mission/repository/StoreRepository.java
+++ b/src/main/java/com/example/umc10th/domain/mission/repository/StoreRepository.java
@@ -1,0 +1,7 @@
+package com.example.umc10th.domain.mission.repository;
+
+import com.example.umc10th.domain.mission.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
+++ b/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
@@ -16,7 +16,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MissionService {
 
-    private final MemberMissionRepository missionRepository;
     private final MemberMissionRepository memberMissionRepository;
 
     // 내 미션 목록 (진행중 / 완료 + 페이징)

--- a/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
+++ b/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
@@ -1,4 +1,35 @@
 package com.example.umc10th.domain.mission.service;
 
+import com.example.umc10th.domain.mission.converter.MissionConverter;
+import com.example.umc10th.domain.mission.dto.MissionResDTO;
+import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+import com.example.umc10th.domain.mission.repository.MemberMissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MissionService {
+
+    private final MemberMissionRepository missionRepository;
+    private final MemberMissionRepository memberMissionRepository;
+
+    // 내 미션 목록 (진행중 / 완료 + 페이징)
+    public MissionResDTO.MissionList getMemberMissions(Long memberId, String status, Integer page, Integer size) {
+        // status를 Boolean으로 변환
+        Boolean isComplete = "COMPLETE".equals(status);
+
+        // Pageable 객체 생성
+        Pageable pageable = PageRequest.of(page, size);
+
+        // @Query 메서드 호출
+        Page<MemberMission> missionPage = memberMissionRepository.findByMemberIdAndStatus(memberId, isComplete, pageable);
+
+        return MissionConverter.toMissionList(missionPage);
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
+++ b/src/main/java/com/example/umc10th/domain/mission/service/MissionService.java
@@ -22,7 +22,7 @@ public class MissionService {
     // 내 미션 목록 (진행중 / 완료 + 페이징)
     public MissionResDTO.MissionList getMemberMissions(Long memberId, String status, Integer page, Integer size) {
         // status를 Boolean으로 변환
-        Boolean isComplete = "COMPLETE".equals(status);
+        Boolean isComplete = "COMPLETED".equals(status);
 
         // Pageable 객체 생성
         Pageable pageable = PageRequest.of(page, size);

--- a/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.example.umc10th.domain.review.controller;
 import com.example.umc10th.domain.review.dto.ReviewReqDTO;
 import com.example.umc10th.domain.review.dto.ReviewResDTO;
 import com.example.umc10th.domain.review.exception.code.ReviewSuccessCode;
+import com.example.umc10th.domain.review.service.ReviewService;
 import com.example.umc10th.global.apiPayload.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
 public class ReviewController {
+    private final ReviewService reviewService;
 
     // private final ReviewService reviewService; 6주차에 활성화
 
@@ -40,17 +42,7 @@ public class ReviewController {
             @PathVariable Long storeId,
             @RequestBody ReviewReqDTO.CreateReview request
     ) {
-        // 6주차에서 reviewService.createReview(storeId, request)로 교체
-        ReviewResDTO.CreateReview result = ReviewResDTO.CreateReview.builder()
-                .reviewId(55L)
-                .storeId(storeId)
-                .memberId(1L)
-                .starRate(request.starRate())
-                .content(request.content())
-                .photoUrls(request.photoUrls())
-                .createdAt(LocalDateTime.now())
-                .build();
-
+        ReviewResDTO.CreateReview result = reviewService.createReview(storeId, request);
         return ApiResponse.onSuccess(ReviewSuccessCode.CREATE_REVIEW, result);
     }
 

--- a/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
@@ -49,25 +49,11 @@ public class ReviewController {
     // 8. 내가 작성한 리뷰 조회
     @GetMapping("/members/me/review")
     public ApiResponse<ReviewResDTO.MyReviewList> getMyReviews(
+            @RequestParam Long memberId,
             @RequestParam(defaultValue = "0") Integer page,
             @RequestParam(defaultValue = "10") Integer size
     ) {
-        // 6주차에서 reviewService.getMyReviews(page, size)로 교체
-        List<ReviewResDTO.MyReviewInfo> reviews = List.of(
-                ReviewResDTO.MyReviewInfo.builder()
-                        .reviewId(55L)
-                        .storeId(3L)
-                        .storeName("현안국밥")
-                        .starRate(new BigDecimal("4.5"))
-                        .content("음식이 맛있고 직원분이 친절했어요.")
-                        .createdAt(LocalDateTime.now())
-                        .build()
-        );
-
-        ReviewResDTO.MyReviewList result = ReviewResDTO.MyReviewList.builder()
-                .reviews(reviews)
-                .build();
-
+        ReviewResDTO.MyReviewList result = reviewService.getMyReviews(memberId, page, size);
         return ApiResponse.onSuccess(ReviewSuccessCode.GET_MY_REVIEWS, result);
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
@@ -1,4 +1,36 @@
 package com.example.umc10th.domain.review.converter;
 
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.mission.entity.Store;
+import com.example.umc10th.domain.review.dto.ReviewReqDTO;
+import com.example.umc10th.domain.review.dto.ReviewResDTO;
+import com.example.umc10th.domain.review.entity.Review;
+
+import java.util.List;
+
 public class ReviewConverter {
+
+    // 요청 -> 엔티티
+    public static Review toReview(ReviewReqDTO.CreateReview request, Member member, Store store) {
+        return Review.builder()
+                .content(request.content())
+                .star(request.starRate())
+                .member(member)
+                .store(store)
+                .build();
+    }
+
+    // 엔티티 -> 응답
+    public static ReviewResDTO.CreateReview toReviewResDTO(Review review, List<String> photoUrls) {
+        return ReviewResDTO.CreateReview.builder()
+                .reviewId(review.getId())
+                .storeId(review.getStore().getId())
+                .memberId(review.getMember().getId())
+                .starRate(review.getStar())
+                .content(review.getContent())
+                .photoUrls(photoUrls)
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
@@ -21,7 +21,7 @@ public class ReviewConverter {
     }
 
     // 엔티티 -> 응답
-    public static ReviewResDTO.CreateReview toReviewResDTO(Review review, List<String> photoUrls) {
+    public static ReviewResDTO.CreateReview toCreateReview(Review review, List<String> photoUrls) {
         return ReviewResDTO.CreateReview.builder()
                 .reviewId(review.getId())
                 .storeId(review.getStore().getId())

--- a/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
@@ -5,6 +5,7 @@ import com.example.umc10th.domain.mission.entity.Store;
 import com.example.umc10th.domain.review.dto.ReviewReqDTO;
 import com.example.umc10th.domain.review.dto.ReviewResDTO;
 import com.example.umc10th.domain.review.entity.Review;
+import com.example.umc10th.global.dto.PageInfoDTO;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -52,8 +53,16 @@ public class ReviewConverter {
                 .map(ReviewConverter::toMyReviewInfo)
                 .toList();
 
+        PageInfoDTO pageInfo = PageInfoDTO.builder()
+                .page(reviewPage.getNumber())
+                .size(reviewPage.getSize())
+                .totalElements(reviewPage.getTotalElements())
+                .totalPages(reviewPage.getTotalPages())
+                .build();
+
         return ReviewResDTO.MyReviewList.builder()
                 .reviews(reviews)
+                .pageInfo(pageInfo)
                 .build();
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
@@ -5,6 +5,7 @@ import com.example.umc10th.domain.mission.entity.Store;
 import com.example.umc10th.domain.review.dto.ReviewReqDTO;
 import com.example.umc10th.domain.review.dto.ReviewResDTO;
 import com.example.umc10th.domain.review.entity.Review;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -33,4 +34,26 @@ public class ReviewConverter {
                 .build();
     }
 
+    // 내가 작성한 리뷰 단건 변환
+    public static ReviewResDTO.MyReviewInfo toMyReviewInfo(Review review) {
+        return ReviewResDTO.MyReviewInfo.builder()
+                .reviewId(review.getId())
+                .storeId(review.getStore().getId())
+                .storeName(review.getStore().getName())
+                .starRate(review.getStar())
+                .content(review.getContent())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+
+    // 페이지 전체 변환
+    public static ReviewResDTO.MyReviewList toMyReviewList(Page<Review> reviewPage) {
+        List<ReviewResDTO.MyReviewInfo> reviews = reviewPage.getContent().stream()
+                .map(ReviewConverter::toMyReviewInfo)
+                .toList();
+
+        return ReviewResDTO.MyReviewList.builder()
+                .reviews(reviews)
+                .build();
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/com/example/umc10th/domain/review/converter/ReviewConverter.java
@@ -53,16 +53,9 @@ public class ReviewConverter {
                 .map(ReviewConverter::toMyReviewInfo)
                 .toList();
 
-        PageInfoDTO pageInfo = PageInfoDTO.builder()
-                .page(reviewPage.getNumber())
-                .size(reviewPage.getSize())
-                .totalElements(reviewPage.getTotalElements())
-                .totalPages(reviewPage.getTotalPages())
-                .build();
-
         return ReviewResDTO.MyReviewList.builder()
                 .reviews(reviews)
-                .pageInfo(pageInfo)
+                .pageInfo(PageInfoDTO.from(reviewPage))
                 .build();
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
@@ -1,5 +1,6 @@
 package com.example.umc10th.domain.review.dto;
 
+import com.example.umc10th.global.dto.PageInfoDTO;
 import lombok.Builder;
 
 import java.math.BigDecimal;
@@ -43,6 +44,7 @@ public class ReviewResDTO {
     // 내가 작성한 리뷰 목록
     @Builder
     public record MyReviewList(
-            List<MyReviewInfo> reviews
+            List<MyReviewInfo> reviews,
+            PageInfoDTO pageInfo
     ) {}
 }

--- a/src/main/java/com/example/umc10th/domain/review/entity/Reply.java
+++ b/src/main/java/com/example/umc10th/domain/review/entity/Reply.java
@@ -1,4 +1,24 @@
 package com.example.umc10th.domain.review.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "reply")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Reply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
 }

--- a/src/main/java/com/example/umc10th/domain/review/entity/Review.java
+++ b/src/main/java/com/example/umc10th/domain/review/entity/Review.java
@@ -1,6 +1,4 @@
 package com.example.umc10th.domain.review.entity;
 
-import lombok.*;
-
 public class Review {
 }

--- a/src/main/java/com/example/umc10th/domain/review/entity/Review.java
+++ b/src/main/java/com/example/umc10th/domain/review/entity/Review.java
@@ -1,4 +1,4 @@
 package com.example.umc10th.domain.review.entity;
-
+import lombok.*;
 public class Review {
 }

--- a/src/main/java/com/example/umc10th/domain/review/entity/Review.java
+++ b/src/main/java/com/example/umc10th/domain/review/entity/Review.java
@@ -1,4 +1,4 @@
 package com.example.umc10th.domain.review.entity;
-import lombok.*;
+
 public class Review {
 }

--- a/src/main/java/com/example/umc10th/domain/review/entity/Review.java
+++ b/src/main/java/com/example/umc10th/domain/review/entity/Review.java
@@ -1,4 +1,46 @@
 package com.example.umc10th.domain.review.entity;
 
-public class Review {
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.mission.entity.Store;
+import com.example.umc10th.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "review")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private BigDecimal star;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<Reply> replyList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<ReviewPhoto> reviewPhotoList = new ArrayList<>();
 }

--- a/src/main/java/com/example/umc10th/domain/review/entity/Review.java
+++ b/src/main/java/com/example/umc10th/domain/review/entity/Review.java
@@ -1,4 +1,6 @@
 package com.example.umc10th.domain.review.entity;
 
+import lombok.*;
+
 public class Review {
 }

--- a/src/main/java/com/example/umc10th/domain/review/entity/ReviewPhoto.java
+++ b/src/main/java/com/example/umc10th/domain/review/entity/ReviewPhoto.java
@@ -1,4 +1,24 @@
 package com.example.umc10th.domain.review.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Table(name = "review_photo")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReviewPhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "photo_url", columnDefinition = "TEXT")
+    private String photoUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
 }

--- a/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ReviewErrorCode implements BaseErrorCode {
-    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "존재하지 않는 리뷰입니다.");
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "존재하지 않는 리뷰입니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_2", "가게를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,20 @@
 package com.example.umc10th.domain.review.repository;
 
 import com.example.umc10th.domain.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository <Review, Long> {
+
+    // 내가 작성한 리뷰 목록 (페이징 + Fetch Join)
+    @Query("SELECT r FROM Review r " +
+            "JOIN FETCH r.store " +
+            "WHERE r.member.id = :memberId")
+    Page<Review> findByMemberId(
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/umc10th/domain/review/repository/ReviewRepository.java
@@ -1,4 +1,7 @@
 package com.example.umc10th.domain.review.repository;
 
-public interface ReviewRepository {
+import com.example.umc10th.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository <Review, Long> {
 }

--- a/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
@@ -28,6 +28,7 @@ public class ReviewService {
     private final MemberMissionRepository memberMissionRepository;
 
     // 리뷰 작성
+    @Transactional
     public ReviewResDTO.CreateReview createReview(Long storeId, ReviewReqDTO.CreateReview request) {
         // 1. memberMissionId로 사용자 식별
         MemberMission memberMission = memberMissionRepository.findById(request.memberMissionId())

--- a/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
@@ -15,6 +15,9 @@ import com.example.umc10th.domain.review.exception.ReviewException;
 import com.example.umc10th.domain.review.exception.code.ReviewErrorCode;
 import com.example.umc10th.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,5 +48,12 @@ public class ReviewService {
 
         // 4. 응답 DTO 변환 (사진은 일단 빈 리스트로)
         return ReviewConverter.toCreateReview(savedReview, request.photoUrls());
+    }
+
+    // 리뷰 조회
+    public ReviewResDTO.MyReviewList getMyReviews(Long memberId, Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Review> reviewPage = reviewRepository.findByMemberId(memberId, pageable);
+        return ReviewConverter.toMyReviewList(reviewPage);
     }
 }

--- a/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/umc10th/domain/review/service/ReviewService.java
@@ -1,4 +1,48 @@
 package com.example.umc10th.domain.review.service;
 
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.mission.entity.Store;
+import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
+import com.example.umc10th.domain.mission.exception.MissionException;
+import com.example.umc10th.domain.mission.exception.code.MissionErrorCode;
+import com.example.umc10th.domain.mission.repository.MemberMissionRepository;
+import com.example.umc10th.domain.mission.repository.StoreRepository;
+import com.example.umc10th.domain.review.converter.ReviewConverter;
+import com.example.umc10th.domain.review.dto.ReviewReqDTO;
+import com.example.umc10th.domain.review.dto.ReviewResDTO;
+import com.example.umc10th.domain.review.entity.Review;
+import com.example.umc10th.domain.review.exception.ReviewException;
+import com.example.umc10th.domain.review.exception.code.ReviewErrorCode;
+import com.example.umc10th.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final StoreRepository storeRepository;
+    private final MemberMissionRepository memberMissionRepository;
+
+    // 리뷰 작성
+    public ReviewResDTO.CreateReview createReview(Long storeId, ReviewReqDTO.CreateReview request) {
+        // 1. memberMissionId로 사용자 식별
+        MemberMission memberMission = memberMissionRepository.findById(request.memberMissionId())
+                .orElseThrow(() -> new MissionException(MissionErrorCode.MEMBER_MISSION_NOT_FOUND));
+        Member member = memberMission.getMember();
+
+        // 2. Store 조회
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new ReviewException(ReviewErrorCode.STORE_NOT_FOUND));
+
+        // 3. Review 생성 & 저장
+        Review review = ReviewConverter.toReview(request, member, store);
+        Review savedReview = reviewRepository.save(review);
+
+        // 4. 응답 DTO 변환 (사진은 일단 빈 리스트로)
+        return ReviewConverter.toCreateReview(savedReview, request.photoUrls());
+    }
 }

--- a/src/main/java/com/example/umc10th/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/umc10th/global/config/SwaggerConfig.java
@@ -24,7 +24,7 @@ public class SwaggerConfig {
                 .addSecuritySchemes(securityScheme, new SecurityScheme()
                         .name(securityScheme)
                         .type(SecurityScheme.Type.HTTP)
-                        .scheme("Bearer")
+                        .scheme("bearer")
                         .bearerFormat("JWT"));
 
         return new OpenAPI()

--- a/src/main/java/com/example/umc10th/global/dto/PageInfoDTO.java
+++ b/src/main/java/com/example/umc10th/global/dto/PageInfoDTO.java
@@ -1,6 +1,7 @@
 package com.example.umc10th.global.dto;
 
 import lombok.Builder;
+import org.springframework.data.domain.Page;
 
 @Builder
 public record PageInfoDTO(
@@ -8,4 +9,13 @@ public record PageInfoDTO(
         Integer size,
         Long totalElements,
         Integer totalPages
-) {}
+) {
+    public static PageInfoDTO from(Page<?> page) {
+        return PageInfoDTO.builder()
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
+    }
+}

--- a/src/main/java/com/example/umc10th/global/dto/PageInfoDTO.java
+++ b/src/main/java/com/example/umc10th/global/dto/PageInfoDTO.java
@@ -1,0 +1,11 @@
+package com.example.umc10th.global.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PageInfoDTO(
+        Integer page,
+        Integer size,
+        Long totalElements,
+        Integer totalPages
+) {}

--- a/src/main/java/com/example/umc10th/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/umc10th/global/entity/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.example.umc10th.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/example/umc10th/global/enums/Address.java
+++ b/src/main/java/com/example/umc10th/global/enums/Address.java
@@ -1,0 +1,4 @@
+package com.example.umc10th.global.enums;
+
+public enum Address {
+}


### PR DESCRIPTION
<!--
  제목은 `[닉네임] 챕터 제목` 로 작성해 주세요.
  예시: [Angela] Chapter 1. 서버란 무엇인가(소켓&멀티 프로세스)
-->
## ✏️ 작업 내용
**미션 1 - 엔티티 제작 및 매핑**
- ERD 기반으로 11개 엔티티 작성 (Member, Food, Term, Mission, Store, Location, Review, Reply, ReviewPhoto + 중간 테이블 3개)
- BaseEntity 분리 + @EnableJpaAuditing 적용으로 createdAt, updatedAt 자동화
- 양방향 매핑은 mappedBy로 연관관계 주인 명시
- @ManyToOne은 모두 FetchType.LAZY로 설정 (N+1 방지)
- 도메인 간 공유되는 Address enum은 global/enums/로 분리
- ERD 일부 수정: Review-Reply 관계를 N:1 → 1:N으로 변경 (FK 위치 이동)

**미션 2 - 서비스, 컨버터, 레포지토리 구현 + 페이징**
- 4개 화면(마이페이지/홈/내 미션/리뷰 작성)에 대한 Service, Repository, Converter 구현
- 페이징 부분은 @Query + Pageable 조합으로 구현
- 5주차에 만든 Controller에 Service 연결

### #️⃣ 연관된 이슈
<!-- 연관된 이슈 번호로 수정해주세요 -->
closes #55 

<br/>

## 💡 함께 공유하고 싶은 부분

- 공통 enum의 위치: Address처럼 여러 도메인이 공유하는 enum을 global에 두는 게 맞는지, 아니면 특정 도메인에 두고 import하는 게 맞는지?
- N+1 문제 체감: Converter에서 mm.getMission().getStore().getName() 처럼 점 찍고 들어가는데, 이게 LAZY 로딩이라 추가 쿼리가 나갈 것 같은데 다들 어떻게 최적화하시는지 궁금합니다.

<br/>

## 🤔 질문

- JpaRepository: 인터페이스에 코드 한 줄 안 썼는데 findById, save가 동작하는 원리가 신기했는데, 스프링이 런타임에 구현체를 주입한다는 게 정확히 어떻게 이루어지는 건가요?
- JPQL의 객체 탐색: WHERE mm.member.id처럼 객체 필드를 점으로 타고 들어가는데, 깊어지면 (예: m.store.location.name) 성능에 영향이 있는지 궁금합니다.
- 페이징 시 Page의 추가 COUNT 쿼리: Page를 반환하면 자동으로 COUNT 쿼리가 한 번 더 나가는데, 데이터가 많을 때도 괜찮은지?

<br/>

## ✅ 워크북 체크리스트

- [x] 모든 핵심 키워드 정리를 마쳤나요?
- [x] 핵심 키워드에 대해 완벽히 이해하셨나요?
- [x] 이론 학습 이후 직접 실습을 해보는 시간을 가졌나요?
- [x] 미션을 수행하셨나요?
- [x] 미션을 기록하셨나요?
      <br>

## ✅ 컨벤션 체크리스트

- [x] 디렉토리 구조 컨벤션을 잘 지켰나요?
- [x] pr 제목을 컨벤션에 맞게 작성하였나요?
- [x] pr에 해당되는 이슈를 연결하였나요?
- [x] 적절한 라벨을 설정하였나요?
- [x] 스터디원들에게 code review를 요청하기 위해 reviewer를 등록하였나요?
- [x] 닉네임/main 브랜치의 최신 상태를 반영하고 있는지 확인했나요?
      <br>

## 📌 주안점

- ERD 수정한 Review-Reply 1:N 관계: FK 위치를 옮긴 게 자연스러운지 의견 주시면 좋겠습니다.

<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분을 설명합니다.
-->
