### PR TITLE
[케이] Chapter 8. Spring Security - Security 구조, 폼 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/umc10th/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/umc10th/domain/member/controller/MemberController.java
@@ -25,13 +25,7 @@ public class MemberController {
     public ApiResponse<MemberResDTO.SignUp> signUp(
             @Valid @RequestBody MemberReqDTO.SignUp request
     ) {
-        // 6주차에서 memberService.signUp(request)로 교체
-        MemberResDTO.SignUp result = MemberResDTO.SignUp.builder()
-                .memberId(1L)
-                .nickname(request.nickname())
-                .email(request.email())
-                .build();
-
+        MemberResDTO.SignUp result = memberService.signUp(request);
         return ApiResponse.onSuccess(MemberSuccessCode.SIGN_UP, result);
     }
 

--- a/src/main/java/com/example/umc10th/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/example/umc10th/domain/member/converter/MemberConverter.java
@@ -1,14 +1,43 @@
 package com.example.umc10th.domain.member.converter;
 
+import com.example.umc10th.domain.member.dto.MemberReqDTO;
 import com.example.umc10th.domain.member.dto.MemberResDTO;
 import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.member.enums.Gender;
 import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
 import com.example.umc10th.global.dto.PageInfoDTO;
+import com.example.umc10th.global.enums.Address;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public class MemberConverter {
+
+    // 회원가입: 요청 DTO -> Member 엔티티
+    public static Member toMember(MemberReqDTO.SignUp request, String encodedPassword) {
+        return Member.builder()
+                .name(request.name())
+                .nickname(request.nickname())
+                .email(request.email())
+                .password(encodedPassword)
+                .phoneNumber(request.phoneNumber())
+                .gender(Gender.valueOf(request.gender()))
+                .birth(request.birth())
+                .address(Address.valueOf(request.address()))
+                .detailAddress(request.detailAddress())
+                // socialType, profileUrl, point는 엔티티의 @Builder.Default로 자동 처리
+                // (LOCAL, 기본 프로필 URL, 0)
+                .build();
+    }
+
+    // 회원가입: 저장된 Member 엔티티 -> 회원가입 응답 DTO
+    public static MemberResDTO.SignUp toSignupResponse(Member member) {
+        return MemberResDTO.SignUp.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .build();
+    }
 
     // 마이페이지 변환
     public static MemberResDTO.MyPage toMyPage(Member member) {

--- a/src/main/java/com/example/umc10th/domain/member/entity/Member.java
+++ b/src/main/java/com/example/umc10th/domain/member/entity/Member.java
@@ -48,12 +48,17 @@ public class Member extends BaseEntity {
     @Column(name = "detail_address", nullable = false, length = 255)
     private String detailAddress;
 
-    @Column(name = "social_uid", nullable = false, length = 255)
+    @Column(name = "social_uid", length = 255)
     private String socialUid;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "social_type", nullable = false)
-    private SocialType socialType;
+    @Builder.Default
+    private SocialType socialType = SocialType.LOCAL;
+
+    // BCrypt 해시 결과는 60자 고정이지만, 알고리즘 변경 대비 여유롭게 100자로 설정
+    @Column(nullable = false, length = 100)
+    private String password;
 
     @Column(nullable = false)
     @Builder.Default
@@ -66,8 +71,10 @@ public class Member extends BaseEntity {
     private String phoneNumber;
 
     // columnDefinition = "TEXT": 255자 이상의 대용량 텍스트 저장 가능 타입으로 지정
+    // 기본 프로필 URL - 회원가입 시 따로 안 받으므로 기본값 박기
     @Column(name = "profile_url", columnDefinition = "TEXT", nullable = false)
-    private String profileUrl;
+    @Builder.Default
+    private String profileUrl = "https://default-profile.example.com/default.png";
 
     // 연관 관계
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)

--- a/src/main/java/com/example/umc10th/domain/member/enums/SocialType.java
+++ b/src/main/java/com/example/umc10th/domain/member/enums/SocialType.java
@@ -1,5 +1,4 @@
 package com.example.umc10th.domain.member.enums;
 
 public enum SocialType {
-    KAKAO, NAVER, APPLE, GOOGLE
 }

--- a/src/main/java/com/example/umc10th/domain/member/enums/SocialType.java
+++ b/src/main/java/com/example/umc10th/domain/member/enums/SocialType.java
@@ -1,4 +1,6 @@
 package com.example.umc10th.domain.member.enums;
 
 public enum SocialType {
+    LOCAL,   // 폼 회원가입 (이메일/비밀번호)
+    KAKAO, NAVER, APPLE, GOOGLE
 }

--- a/src/main/java/com/example/umc10th/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/member/exception/code/MemberErrorCode.java
@@ -9,7 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "회원을 찾을 수 없습니다."),
-    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER409_1", "이미 존재하는 유저입니다.");
+    MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER409_1", "이미 존재하는 유저입니다."),
+
+    // 회원가입 관련 에러
+    FOOD_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER400_1", "유효하지 않은 선호 음식입니다."),
+    TERM_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER400_2", "유효하지 않은 약관입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/umc10th/domain/member/repository/FoodRepository.java
+++ b/src/main/java/com/example/umc10th/domain/member/repository/FoodRepository.java
@@ -1,0 +1,10 @@
+package com.example.umc10th.domain.member.repository;
+
+import com.example.umc10th.domain.member.entity.Food;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FoodRepository extends JpaRepository<Food, Long> {
+    Optional<Food> findByName(com.example.umc10th.domain.member.enums.Food name);
+}

--- a/src/main/java/com/example/umc10th/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/umc10th/domain/member/repository/MemberRepository.java
@@ -3,7 +3,15 @@ package com.example.umc10th.domain.member.repository;
 import com.example.umc10th.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 // JpaRepository: Spring Data JPA가 제공하는 인터페이스로, 기본적인 CRUD 메서드를 자동으로 구현해준다.
 // <Member, Long>: 이 Repository는 Member 엔터티를 관리하며, Member 엔터티의 기본 키(PK) 타입이 Long임을 나타낸다.
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    // 회원가입 시 이메일 중복 체크용
+    boolean existsByEmail(String email);
+
+    // 로그인에서 사용자 이메일로 회원 조회
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/example/umc10th/domain/member/repository/TermRepository.java
+++ b/src/main/java/com/example/umc10th/domain/member/repository/TermRepository.java
@@ -1,0 +1,10 @@
+package com.example.umc10th.domain.member.repository;
+
+import com.example.umc10th.domain.member.entity.Term;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TermRepository extends JpaRepository<Term, Long> {
+    Optional<Term> findByName(com.example.umc10th.domain.member.enums.Term name);
+}

--- a/src/main/java/com/example/umc10th/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/umc10th/domain/member/service/MemberService.java
@@ -1,17 +1,27 @@
 package com.example.umc10th.domain.member.service;
 
 import com.example.umc10th.domain.member.converter.MemberConverter;
+import com.example.umc10th.domain.member.dto.MemberReqDTO;
 import com.example.umc10th.domain.member.dto.MemberResDTO;
+import com.example.umc10th.domain.member.entity.Food;
 import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.member.entity.Term;
+import com.example.umc10th.domain.member.entity.mapping.MemberFood;
+import com.example.umc10th.domain.member.entity.mapping.MemberTerm;
 import com.example.umc10th.domain.member.exception.MemberException;
 import com.example.umc10th.domain.member.exception.code.MemberErrorCode;
+import com.example.umc10th.domain.member.repository.FoodRepository;
 import com.example.umc10th.domain.member.repository.MemberRepository;
+import com.example.umc10th.domain.member.repository.TermRepository;
 import com.example.umc10th.domain.mission.entity.mapping.MemberMission;
 import com.example.umc10th.domain.mission.repository.MemberMissionRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +34,71 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberMissionRepository memberMissionRepository;
+    private final FoodRepository foodRepository;
+    private final TermRepository termRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @PersistenceContext
+    private EntityManager em; // MemberFood/MemberTerm을 직접 persist하기 위해
+
+    // 회원가입
+    @Transactional
+    public MemberResDTO.SignUp signUp(MemberReqDTO.SignUp request) {
+
+        // 1. 이메일 중복 체크
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new MemberException(MemberErrorCode.MEMBER_ALREADY_EXISTS);
+        }
+
+        // 2. 비밀번호 BCrypt 인코딩
+        String encodedPassword = passwordEncoder.encode(request.password());
+
+        // 3. Member 엔티티 생성 및 저장
+        Member member = MemberConverter.toMember(request, encodedPassword);
+        Member savedMember = memberRepository.save(member);
+
+        // 4. 선호 음식 매핑 저장
+        for (String foodName: request.preferredFoods()) {
+            com.example.umc10th.domain.member.enums.Food foodEnum;
+            try {
+                foodEnum = com.example.umc10th.domain.member.enums.Food.valueOf(foodName);
+            } catch (IllegalArgumentException e) {
+                throw new MemberException(MemberErrorCode.FOOD_NOT_FOUND);
+            }
+
+            Food food = foodRepository.findByName(foodEnum)
+                    .orElseThrow(() -> new MemberException(MemberErrorCode.FOOD_NOT_FOUND));
+
+            MemberFood memberFood = MemberFood.builder()
+                    .member(savedMember)
+                    .food(food)
+                    .build();
+
+            em.persist(memberFood);
+        }
+
+        // 5. 약관 동의 매핑 저장
+        for (String termName: request.agreedTerms()) {
+            com.example.umc10th.domain.member.enums.Term termEnum;
+            try {
+                termEnum = com.example.umc10th.domain.member.enums.Term.valueOf(termName);
+            } catch (IllegalArgumentException e) {
+                throw new MemberException(MemberErrorCode.TERM_NOT_FOUND);
+            }
+
+            Term term = termRepository.findByName(termEnum)
+                    .orElseThrow(() -> new MemberException(MemberErrorCode.TERM_NOT_FOUND));
+
+            MemberTerm memberTerm = MemberTerm.builder()
+                    .member(savedMember)
+                    .term(term)
+                    .build();
+
+            em.persist(memberTerm);
+        }
+
+        return MemberConverter.toSignupResponse(savedMember);
+    }
 
     // 마이페이지
     public MemberResDTO.MyPage getMyPage(Long memberId) {

--- a/src/main/java/com/example/umc10th/global/config/InitDataLoader.java
+++ b/src/main/java/com/example/umc10th/global/config/InitDataLoader.java
@@ -1,0 +1,54 @@
+package com.example.umc10th.global.config;
+
+import com.example.umc10th.domain.member.entity.Food;
+import com.example.umc10th.domain.member.entity.Term;
+import com.example.umc10th.domain.member.repository.FoodRepository;
+import com.example.umc10th.domain.member.repository.TermRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+// CommandLineRunner:  Spring이 제공하는 인터페이스
+// 이걸 구현하면 애플리케이션이 시작된 직후에 run() 메서드가 자동으로 호출된다.
+public class InitDataLoader implements CommandLineRunner {
+
+    private final FoodRepository foodRepository;
+    private final TermRepository termRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        seedFoods();
+        seedTerms();
+    }
+
+    private void seedFoods() {
+        // enum의 모든 값을 순회하면서, DB에 없는 것만 INSERT
+        Arrays.stream(com.example.umc10th.domain.member.enums.Food.values())
+                .filter(foodEnum -> foodRepository.findByName(foodEnum).isEmpty())
+                .forEach(foodEnum -> {
+                    foodRepository.save(Food.builder()
+                            .name(foodEnum)
+                            .build());
+                    log.info("[InitDataLoader] Food 시드: {}", foodEnum);
+                });
+    }
+
+    private void seedTerms() {
+        Arrays.stream(com.example.umc10th.domain.member.enums.Term.values())
+                .filter(termEnum -> termRepository.findByName(termEnum).isEmpty())
+                .forEach(termEnum -> {
+                    termRepository.save(Term.builder()
+                            .name(termEnum)
+                            .build());
+                    log.info("[InitDataLoader] Term 시드: {}", termEnum);
+                });
+    }
+}

--- a/src/main/java/com/example/umc10th/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/umc10th/global/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package com.example.umc10th.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    private final String[] allowUris = {
+            // Swagger 허용
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+            "/auth/**"
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers(allowUris).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form
+                        .defaultSuccessUrl("/swagger-ui/index.html", true)
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/login?logout")
+                        .permitAll()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/umc10th/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/umc10th/global/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.example.umc10th.global.config;
 
+import com.example.umc10th.global.security.CustomAccessDenied;
+import com.example.umc10th.global.security.CustomEntryPoint;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -11,14 +14,22 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @EnableWebSecurity
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CustomEntryPoint customEntryPoint;
+    private final CustomAccessDenied customAccessDenied;
 
     private final String[] allowUris = {
             // Swagger 허용
             "/swagger-ui/**",
             "/swagger-resources/**",
             "/v3/api-docs/**",
-            "/auth/**"
+            "/auth/**",
+
+            // 폼 로그인 페이지 자체
+            "/login",
+            "/login/**"
     };
 
     @Bean
@@ -28,6 +39,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(requests -> requests
                         .requestMatchers(allowUris).permitAll()
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customEntryPoint)
+                        .accessDeniedHandler(customAccessDenied)
                 )
                 .formLogin(form -> form
                         .defaultSuccessUrl("/swagger-ui/index.html", true)

--- a/src/main/java/com/example/umc10th/global/security/AuthMember.java
+++ b/src/main/java/com/example/umc10th/global/security/AuthMember.java
@@ -1,0 +1,35 @@
+package com.example.umc10th.global.security;
+
+import com.example.umc10th.domain.member.entity.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class AuthMember implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        // 지금은 단일 권한 ROLE_USER만
+        // 나중에 ADMIN 등 추가 시 여기서 분기
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+}

--- a/src/main/java/com/example/umc10th/global/security/CustomAccessDenied.java
+++ b/src/main/java/com/example/umc10th/global/security/CustomAccessDenied.java
@@ -1,0 +1,27 @@
+package com.example.umc10th.global.security;
+
+import com.example.umc10th.global.apiPayload.code.GeneralErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDenied implements AccessDeniedHandler {
+
+    private final SecurityResponseWriter responseWriter;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        responseWriter.write(response, GeneralErrorCode.FORBIDDEN);
+    }
+}

--- a/src/main/java/com/example/umc10th/global/security/CustomEntryPoint.java
+++ b/src/main/java/com/example/umc10th/global/security/CustomEntryPoint.java
@@ -1,0 +1,27 @@
+package com.example.umc10th.global.security;
+
+import com.example.umc10th.global.apiPayload.code.GeneralErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomEntryPoint implements AuthenticationEntryPoint {
+
+    private final SecurityResponseWriter responseWriter;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        responseWriter.write(response, GeneralErrorCode.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/example/umc10th/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/example/umc10th/global/security/CustomUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.example.umc10th.global.security;
+
+import com.example.umc10th.domain.member.entity.Member;
+import com.example.umc10th.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException(
+                        "해당 이메일의 회원을 찾을 수 없습니다: " + email
+                ));
+        return new AuthMember(member);
+    }
+}

--- a/src/main/java/com/example/umc10th/global/security/SecurityResponseWriter.java
+++ b/src/main/java/com/example/umc10th/global/security/SecurityResponseWriter.java
@@ -1,0 +1,26 @@
+package com.example.umc10th.global.security;
+
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityResponseWriter {
+
+    private ObjectMapper objectMapper;
+
+    public void write(HttpServletResponse response, BaseErrorCode code) throws IOException {
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(code.getStatus().value());
+
+        ApiResponse<Void> errorResponse = ApiResponse.onFailure(code, null);
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}


### PR DESCRIPTION
<!--
  제목은 `[닉네임] 챕터 제목` 로 작성해 주세요.
  예시: [Angela] Chapter 1. 서버란 무엇인가(소켓&멀티 프로세스)
-->
## ✏️ 작업 내용
### Spring Security 도입
- `build.gradle`에 Spring Security 의존성 추가
- `SecurityConfig` 신규 작성 (Public/Private 분리, formLogin, logout, exceptionHandling)
- `PasswordEncoder` Bean으로 `BCryptPasswordEncoder` 등록

### 회원가입 API 구현
- `MemberReqDTO.SignUp`에 이미 정의된 `email`, `password` 활용
- `Member` 엔티티에 `password` 필드 추가
- 폼 회원가입을 위해 `socialUid`는 nullable, `socialType`은 `LOCAL` 기본값 처리
- `profileUrl`은 `@Builder.Default`로 기본 URL 박아둠
- `SocialType` enum에 `LOCAL` 추가
- `MemberRepository`에 `existsByEmail`, `findByEmail` 쿼리 메서드 추가
- `FoodRepository`, `TermRepository` 신규 작성 (`findByName`)
- `MemberConverter`에 `toMember`, `toSignUpResponse` 추가
- `MemberService.signUp` 구현 (이메일 중복 체크 -> BCrypt 인코딩 -> Member 저장 -> MemberFood/MemberTerm 매핑 저장)
- `MemberController`의 Mock 응답 제거 후 실제 서비스 호출로 교체
- `MemberErrorCode`에 `FOOD_NOT_FOUND`, `TERM_NOT_FOUND` 추가

### 시드 데이터 처리
- `InitDataLoader` (`CommandLineRunner` 구현) 추가
- `Food`/`Term` enum 값을 DB에 멱등하게 INSERT (이미 있는 값은 건너뜀)

### 인증/인가 처리 및 응답 통일
- `AuthMember` (`UserDetails` 구현체): `Member`를 감싸는 어댑터
- `CustomUserDetailsService` (`UserDetailsService` 구현): 이메일로 회원 조회
- `SecurityResponseWriter`: 401/403 JSON 응답 공통 유틸
- `CustomEntryPoint` (`AuthenticationEntryPoint`): 인증 실패(401) 시 통일된 JSON 응답
- `CustomAccessDenied` (`AccessDeniedHandler`): 인가 실패(403) 시 통일된 JSON 응답


### #️⃣ 연관된 이슈
<!-- 연관된 이슈 번호로 수정해주세요 -->
closes #110 

<br/>

## 💡 함께 공유하고 싶은 부분

### 1. `@RestControllerAdvice`가 잡지 못하는 영역이 있다
`CustomUserDetailsService`는 Spring Security 필터 체인 안에서 호출되기 때문에 `DispatcherServlet`에 도달하지 못한다. 즉, 여기서 발생한 도메인 예외(`MemberException` 등)는 기존 `GeneralExceptionAdvice`가 잡지 못한다.

```
[잡히는 경로]   컨트롤러 → @RestControllerAdvice
[잡히지 않는 경로]   필터 체인 안 → 500 에러로 새어 나감
```

그래서 `CustomUserDetailsService.loadUserByUsername`에서는 도메인 예외 대신 Spring Security 표준 예외인 `UsernameNotFoundException`을 던지도록 구현했다. Spring Security의 `DaoAuthenticationProvider`가 이 예외를 잡아서 인증 실패로 변환해주고, 그러면 `CustomEntryPoint`가 동작해 통일된 401 JSON 응답이 나간다.

### 2. 시드 데이터 처리 필요성
회원가입 시 `preferredFoods`, `agreedTerms`를 받아서 `Food`/`Term` 테이블에서 조회한 뒤 `MemberFood`/`MemberTerm`으로 매핑한다. 그런데 `food`/`term` 테이블이 비어있으면 `findByName()`이 실패해서 회원가입 자체가 안 된다.

이걸 해결하려고 `CommandLineRunner`로 `InitDataLoader`를 만들어서 서버 부팅 시 enum 값들을 DB에 자동 시드하도록 처리했다. `filter(... isEmpty())`로 DB에 없는 값만 INSERT하게 해서, 재시작할 때마다 중복 삽입되지 않도록 멱등성을 확보했다.

### 3. 어댑터 패턴으로 도메인과 프레임워크 분리
`Member` 엔티티에 직접 `implements UserDetails`를 박는 방식도 가능하지만, 그러면 도메인 엔티티가 Spring Security에 의존하게 된다. 그래서 `AuthMember`라는 어댑터 클래스를 따로 만들어 `Member`를 감싸는 방식으로 구현했다. 이렇게 하면 `Member`는 순수한 도메인 객체로 남고, Spring Security 관련 처리는 `AuthMember`가 전담한다.

<br/>

## 🤔 질문

### Q1. `SocialType` enum에 `LOCAL`을 추가하는 설계가 맞을까요?
폼 회원가입 회원을 구분하기 위해 `SocialType` enum에 `LOCAL`을 추가하고, `social_uid`를 nullable로 변경했습니다. 가장 단순한 방식이라 학습 단계에 맞다고 판단했지만, 의미적으로는 어색한 부분이 있는 것 같습니다.

- LOCAL은 사실 소셜이 아닌데 `SocialType`에 포함시켜도 되는지 궁금합니다.
- 별도 테이블 분리(`LocalAuth`/`SocialAuth`)나 `AuthType` enum 분리 같은 다른 방식과 비교했을 때, 실무에서는 어떤 기준으로 선택하나요?

### Q2. `CustomUserDetailsService`에서 `UsernameNotFoundException`을 던지는 게 맞을까요?
워크북에서는 `loadUserByUsername`에서 도메인 예외를 던지는 예시도 나왔는데, 위에서 설명한 이유로 `UsernameNotFoundException`을 던지는 방식으로 구현했습니다. 워크북에서 도메인 예외를 사용한 의도가 따로 있었는지, 실무에서는 어떤 선택이 일반적인지 궁금합니다.

### Q3. `Food`/`Term` 시드 데이터는 다른 분들은 어떻게 처리하셨나요?
회원가입에서 `preferredFoods`, `agreedTerms` 매핑을 구현하면서 시드 데이터의 필요성을 알게 됐습니다. `CommandLineRunner`로 처리했는데, 다른 분들은 어떻게 했는지 궁금합니다.

- DB에 직접 INSERT 해두었는지, 저처럼 `CommandLineRunner`로 처리했는지 궁금합니다.

<br/>

## ✅ 워크북 체크리스트

- [x] 모든 핵심 키워드 정리를 마쳤나요?
- [x] 핵심 키워드에 대해 완벽히 이해하셨나요?
- [x] 이론 학습 이후 직접 실습을 해보는 시간을 가졌나요?
- [x] 미션을 수행하셨나요?
- [x] 미션을 기록하셨나요?
      <br>

## ✅ 컨벤션 체크리스트

- [x] 디렉토리 구조 컨벤션을 잘 지켰나요?
- [x] pr 제목을 컨벤션에 맞게 작성하였나요?
- [x] pr에 해당되는 이슈를 연결하였나요?
- [x] 적절한 라벨을 설정하였나요?
- [x] 스터디원들에게 code review를 요청하기 위해 reviewer를 등록하였나요?
- [x] 닉네임/main 브랜치의 최신 상태를 반영하고 있는지 확인했나요?
      <br>

## 📌 주안점

- **`CustomUserDetailsService`에서 `UsernameNotFoundException` 사용**
- **`Member` 엔티티의 변경 사항**: `password` 필드 추가, `socialUid` nullable 처리, `socialType`/`profileUrl` 기본값 처리가 적절한지

<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분을 설명합니다.
-->
